### PR TITLE
CET-9696 Require current year in the copyright claim

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'notice/notice': [
       'error',
       {
+        mustMatch: "Copyright %YEAR% Cortex Applications, Inc.".replace("%YEAR%", new Date().getFullYear().toString()),
         templateFile: path.resolve(__dirname, 'notice-template.txt'),
       },
     ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/cortexapps/eslint-config-oss.git"
   },
   "license": "Apache-2.0",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "./index.js",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.10.2",


### PR DESCRIPTION
https://cortex1.atlassian.net/browse/CET-9696

We want to have the current year in the copyright claim. This PR requires it in the file headers.

![image1](https://github.com/user-attachments/assets/bc3c004f-eab2-4d99-a00d-5ed9fe77a109)
![image2](https://github.com/user-attachments/assets/4eb7d2ec-fe00-4224-8785-5e566661669d)